### PR TITLE
二级目录添加时令字段

### DIFF
--- a/doc/api/goods.md
+++ b/doc/api/goods.md
@@ -20,14 +20,6 @@
         "data": {
             "data": [
                 {
-                    "id": 2,
-                    "gmtCreate": 1555225976000,
-                    "gmtModified": 1555225976000,
-                    "name": "test-1",
-                    "description": null,
-                    "catalogTwoList": []
-                },
-                {
                     "id": 1,
                     "gmtCreate": 1553425721000,
                     "gmtModified": 1553425721000,
@@ -36,26 +28,28 @@
                     "catalogTwoList": [
                         {
                             "id": 2,
-                            "gmtCreate": 1555225869000,
-                            "gmtModified": 1555225869000,
-                            "name": "test-1",
+                            "gmtCreate": 1556681686000,
+                            "gmtModified": 1556681686000,
+                            "name": "test",
                             "description": null,
-                            "catalogOneId": 1
+                            "catalogOneId": 1,
+                            "season": 0
                         },
                         {
                             "id": 1,
-                            "gmtCreate": 1553426662000,
-                            "gmtModified": 1553426662000,
-                            "name": "test",
+                            "gmtCreate": 1556681654000,
+                            "gmtModified": 1556681654000,
+                            "name": "test-1",
                             "description": null,
-                            "catalogOneId": 1
+                            "catalogOneId": 1,
+                            "season": 0
                         }
                     ]
                 }
             ],
             "pageNo": 1,
             "pageSize": 10,
-            "totalCount": 2
+            "totalCount": 1
         }
     }
     
@@ -78,19 +72,21 @@
             "data": [
                 {
                     "id": 2,
-                    "gmtCreate": 1555225869000,
-                    "gmtModified": 1555225869000,
-                    "name": "test-1",       //二级目录名称
+                    "gmtCreate": 1556681686000,
+                    "gmtModified": 1556681686000,
+                    "name": "test",
                     "description": null,
-                    "catalogOneId": 1
+                    "catalogOneId": 1,
+                    "season": 0
                 },
                 {
                     "id": 1,
-                    "gmtCreate": 1553426662000,
-                    "gmtModified": 1553426662000,
-                    "name": "test",
+                    "gmtCreate": 1556681654000,
+                    "gmtModified": 1556681654000,
+                    "name": "test-1",
                     "description": null,
-                    "catalogOneId": 1
+                    "catalogOneId": 1,
+                    "season": 0
                 }
             ],
             "pageNo": 1,

--- a/doc/database/database-description.md
+++ b/doc/database/database-description.md
@@ -103,6 +103,7 @@
 |   name    |   varchar(16) |   String  |   目录名称    |   not null    |   |
 |   description |   varchar(256)    |   String  |   描述  |   null    |   |
 |   catalog_one_id  |   int  |   Long   |   外键依赖一级目录    |   FK(goods_catalog_one), not null |   |
+|   season  |   int  |   Integer   |   时令    |   0表示不区分,1-12表示具体月份 |   |
 
 其它说明：
 
@@ -131,6 +132,7 @@
 |   goods_info  |   text    |   String  |   商品信息(富文本)    |   not null    |   |
 |   price   |   decimal     |   Double  |   价格      |   null    |   |
 |   remarks     |   varchar(512)    |   String      |   备注      |   null    |   |
+|   cover_img     |   varchar(256)    |   String      |   封面图片      |   null    |   |
 |   business_id    |   bigint |   Long  |   商户ID  |   FK(business_info), not null    |   |
 
 

--- a/src/main/java/com/chenlinghong/graduation/repository/domain/GoodsCatalogTwo.java
+++ b/src/main/java/com/chenlinghong/graduation/repository/domain/GoodsCatalogTwo.java
@@ -30,6 +30,11 @@ public class GoodsCatalogTwo extends BaseDomain {
      */
     private Long catalogOneId;
 
+    /**
+     * 时令
+     */
+    private Integer season;
+
     public GoodsCatalogTwo(String name, long catalogOneId) {
         this.name = name;
         this.catalogOneId = catalogOneId;

--- a/src/main/resources/database/schema.sql
+++ b/src/main/resources/database/schema.sql
@@ -79,6 +79,7 @@ create table if not exists `goods_catalog_two` (
     `name` varchar(16) null comment '目录名称',
     `description` varchar(256) null comment '描述',
     `catalog_one_id` int not null comment '一级目录ID，FK(goods_catalog_one)',
+    `season` int null default '0' comment '时令，0代表尚未分类',
     primary key (`id`),
     unique key `uk_name`(`name`),
     index `idx_name`(`name`)

--- a/src/main/resources/mapper/GoodsCatalogTwoMapper.xml
+++ b/src/main/resources/mapper/GoodsCatalogTwoMapper.xml
@@ -12,10 +12,11 @@
         <result column="name" property="name" jdbcType="VARCHAR" javaType="String"/>
         <result column="description" property="description" jdbcType="VARCHAR" javaType="String"/>
         <result column="catalog_one_id" property="catalogOneId" jdbcType="INTEGER" javaType="Long"/>
+        <result column="season" property="season" jdbcType="INTEGER" javaType="Integer"/>
     </resultMap>
 
     <sql id="Base_Column_List">
-        gmt_create, gmt_modified, deleted, `name`, `description`, `catalog_one_id`
+        gmt_create, gmt_modified, deleted, `name`, `description`, `catalog_one_id`, `season`
     </sql>
 
     <sql id="column_list">
@@ -36,7 +37,7 @@
         <include refid="Base_Column_List"/>
         )
         values(
-        <include refid="value_list"/>,#{name},#{description}, #{catalogOneId}
+        <include refid="value_list"/>,#{name},#{description}, #{catalogOneId}, #{season}
         )
     </insert>
 

--- a/src/test/java/com/chenlinghong/graduation/repository/dao/GoodsCatalogTwoDaoTest.java
+++ b/src/test/java/com/chenlinghong/graduation/repository/dao/GoodsCatalogTwoDaoTest.java
@@ -20,7 +20,7 @@ public class GoodsCatalogTwoDaoTest {
 
     @Test
     public void insert() {
-        GoodsCatalogTwo catalogTwo = new GoodsCatalogTwo("test-1", 1);
+        GoodsCatalogTwo catalogTwo = new GoodsCatalogTwo("test", 1);
         int result = catalogTwoDao.insert(catalogTwo);
         Assert.assertEquals(1, result);
         System.out.println(result);


### PR DESCRIPTION
1、二级目录添加时令字段（0代表不区分，1-12表示具体月份）
2、已在数据库说明文档进行完善字段说明，包括goods添加的cover_img，goods_catalog_two添加的season。
3、已在服务器数据库添加字段，还需进一步进行之前录入数据的修改。